### PR TITLE
Add interactive route builder tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The interface lets you edit customer nodes in a table, configure the number of v
 - Editable node table
 - Map view of routes and nodes
 - 24‑hour Gantt view of each vehicle's schedule
-- Custom route visualisation by selecting nodes in order
+- Custom route visualisation by selecting nodes in order, with support for multiple colour‑coded routes
 - Cached solutions saved to `solution_cache.json`
 - Comprehensive logging system for solver execution tracking
 - Log viewer in the UI to monitor solver performance and execution details

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The interface lets you edit customer nodes in a table, configure the number of v
 - Editable node table
 - Map view of routes and nodes
 - 24‑hour Gantt view of each vehicle's schedule
+- Custom route visualisation by selecting nodes in order
 - Cached solutions saved to `solution_cache.json`
 - Comprehensive logging system for solver execution tracking
 - Log viewer in the UI to monitor solver performance and execution details

--- a/app.py
+++ b/app.py
@@ -57,7 +57,11 @@ COLS_CFG = [{"id": c, "name": c} for c in ["id", "x", "y", "demand", "ready", "d
 # Dash UI
 # --------------------------------------------------------------------------------------
 
-app = dash.Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])
+app = dash.Dash(
+    __name__,
+    external_stylesheets=[dbc.themes.BOOTSTRAP],
+    suppress_callback_exceptions=True,
+)
 app.title = "CVRPTW Solver (Modular)"
 
 app.layout = dbc.Container(


### PR DESCRIPTION
## Summary
- Add Route tab with multi-select dropdown to plot custom node paths on map
- Include callback to draw user-selected path and connect nodes in order
- Document new route visualisation feature in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689aae422358832599201060c866708b